### PR TITLE
Bump actions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -2,7 +2,6 @@ on:
   push:
     branches:
       - master
-      - bump-actions
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - master
+      - bump-actions
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -25,7 +26,7 @@ jobs:
     name: Build project
     steps:
       - name: Checkout project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -42,7 +43,7 @@ jobs:
         run: ~/.elan/bin/lake -Kenv=dev build BonnAnalysis
 
       - name: Cache mathlib documentation
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             .lake/build/doc/Init
@@ -105,13 +106,13 @@ jobs:
       #     path: docs/
 
       - name: Upload docs & blueprint artifact to `docs/_site`
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: docs/_site
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4
 
       - name: Make sure the cache works
         run: mv docs/docs .lake/build/doc

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -7,7 +7,7 @@ jobs:
     name: Build project
     steps:
       - name: Checkout project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Changes

- [x] Bump actions/cache from 3 to 4
- [x] Bump actions/upload-pages-artifact from 1 to 3
- [x] Bump actions/deploy-pages from 1 to 4
- [x] Bump actions/checkout from 2 to 4

## Effects

- Solved all warnings 
- Disk space usage seems to be reduced significantly (from 357 MB to just 19 MB), but I think it's nothing but a change in the variable displayed (from uncompressed to compressed size)